### PR TITLE
Make use of latest Azul3D audio API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ waveform [![Build Status](https://travis-ci.org/mdlayher/waveform.svg?branch=mas
 
 Go package capable of generating waveform images from audio streams.  MIT Licensed.
 
-This library supports any audio streams which the [azul3d/audio.v1](http://azul3d.org/audio.v1)
+This library supports any audio streams which the [azul3d/engine/audio](http://azul3d.org/engine/audio)
 package is able to decode.  At the time of writing, this includes:
   - WAV
   - FLAC

--- a/samplereducefunc.go
+++ b/samplereducefunc.go
@@ -3,23 +3,23 @@ package waveform
 import (
 	"math"
 
-	"azul3d.org/audio.v1"
+	"azul3d.org/engine/audio"
 )
 
 // SampleReduceFunc is a function which reduces a set of float64 audio samples
 // into a single float64 value.
-type SampleReduceFunc func(samples audio.F64Samples) float64
+type SampleReduceFunc func(samples audio.Float64) float64
 
 // RMSF64Samples is a SampleReduceFunc which calculates the root mean square
 // of a slice of float64 audio samples, enabling the measurement of magnitude
 // over the entire set of samples.
 //
 // Derived from: http://en.wikipedia.org/wiki/Root_mean_square.
-func RMSF64Samples(samples audio.F64Samples) float64 {
+func RMSF64Samples(samples audio.Float64) float64 {
 	// Square and sum all input samples
 	var sumSquare float64
 	for i := range samples {
-		sumSquare += math.Pow(float64(samples.At(i)), 2)
+		sumSquare += math.Pow(samples.At(i), 2)
 	}
 
 	// Multiply squared sum by length of samples slice, return square root

--- a/samplereducefunc_test.go
+++ b/samplereducefunc_test.go
@@ -4,30 +4,30 @@ import (
 	"math"
 	"testing"
 
-	"azul3d.org/audio.v1"
+	"azul3d.org/engine/audio"
 )
 
 // TestRMSF64Samples verifies that RMSF64Samples computes correct results
 func TestRMSF64Samples(t *testing.T) {
 	var tests = []struct {
-		samples audio.F64Samples
+		samples audio.Float64
 		result  float64
 		isNaN   bool
 	}{
 		// Empty samples - NaN
-		{audio.F64Samples{}, 0.00, true},
+		{audio.Float64{}, 0.00, true},
 		// Negative samples
-		{audio.F64Samples{-0.10}, 0.10, false},
-		{audio.F64Samples{-0.10, -0.20}, 0.15811388300841897, false},
-		{audio.F64Samples{-0.10, -0.20, -0.30, -0.40, -0.50}, 0.33166247903554, false},
+		{audio.Float64{-0.10}, 0.10, false},
+		{audio.Float64{-0.10, -0.20}, 0.15811388300841897, false},
+		{audio.Float64{-0.10, -0.20, -0.30, -0.40, -0.50}, 0.33166247903554, false},
 		// Positive samples
-		{audio.F64Samples{0.10}, 0.10, false},
-		{audio.F64Samples{0.10, 0.20}, 0.15811388300841897, false},
-		{audio.F64Samples{0.10, 0.20, 0.30, 0.40, 0.50}, 0.33166247903554, false},
+		{audio.Float64{0.10}, 0.10, false},
+		{audio.Float64{0.10, 0.20}, 0.15811388300841897, false},
+		{audio.Float64{0.10, 0.20, 0.30, 0.40, 0.50}, 0.33166247903554, false},
 		// Mixed samples
-		{audio.F64Samples{0.10}, 0.10, false},
-		{audio.F64Samples{0.10, -0.20}, 0.15811388300841897, false},
-		{audio.F64Samples{0.10, -0.20, 0.30, -0.40, 0.50}, 0.33166247903554, false},
+		{audio.Float64{0.10}, 0.10, false},
+		{audio.Float64{0.10, -0.20}, 0.15811388300841897, false},
+		{audio.Float64{0.10, -0.20, 0.30, -0.40, 0.50}, 0.33166247903554, false},
 	}
 
 	for i, test := range tests {

--- a/waveform.go
+++ b/waveform.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"math"
 
-	"azul3d.org/audio.v1"
+	"azul3d.org/engine/audio"
 
 	// Import WAV and FLAC decoders
-	_ "azul3d.org/audio/wav.v1"
-	_ "github.com/azul3d/audio-flac"
+	_ "azul3d.org/engine/audio/flac"
+	_ "azul3d.org/engine/audio/wav"
 )
 
 const (
@@ -23,8 +23,8 @@ const (
 	scaleDefault = 3.00
 )
 
-// Error values from azul3d/audio.v1 are wrapped, so that callers do not have to
-// import an additional package to check for common errors.
+// Error values from azul3d/engine/audio are wrapped, so that callers do not
+// have to import an additional package to check for common errors.
 var (
 	// ErrFormat is returned when the input audio format is not a registered format
 	// with the audio package.
@@ -172,7 +172,7 @@ func (w *Waveform) readAndComputeSamples() ([]float64, error) {
 
 	// samples is a slice of float64 audio samples, used to store decoded values
 	config := decoder.Config()
-	samples := make(audio.F64Samples, uint(config.SampleRate*config.Channels)/w.resolution)
+	samples := make(audio.Float64, uint(config.SampleRate*config.Channels)/w.resolution)
 	for {
 		// Decode at specified resolution from options
 		// On any error other than end-of-stream, return

--- a/waveform_bench_test.go
+++ b/waveform_bench_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"azul3d.org/audio.v1"
+	"azul3d.org/engine/audio"
 )
 
 // BenchmarkGenerateWAV checks the performance of the Generate() function with a WAV file
@@ -119,9 +119,9 @@ func benchmarkWaveformDraw(b *testing.B, count int) {
 func benchmarkRMSF64Samples(b *testing.B, count int) {
 	// Generate slice of samples
 	rand.Seed(time.Now().UnixNano())
-	var samples audio.F64Samples
+	var samples audio.Float64
 	for i := 0; i < count; i++ {
-		samples = append(samples, audio.F64(rand.Float64()))
+		samples = append(samples, rand.Float64())
 	}
 
 	// Reset timer and start benchmark


### PR DESCRIPTION
Updates mewkiz/flac#13.

For background information on the changes to Azul3D and the
audio package, see azul3d/engine#1 and azul3d/engine#76.