### PR TITLE
Reformat Markdown files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,20 @@
-MIT License
-===========
+# MIT License
 
-Copyright (C) 2014 Matt Layher
+Copyright &copy; 2014 Matt Layher
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
-waveform [![Build Status](https://travis-ci.org/mdlayher/waveform.svg?branch=master)](https://travis-ci.org/mdlayher/waveform) [![GoDoc](http://godoc.org/github.com/mdlayher/waveform?status.svg)](http://godoc.org/github.com/mdlayher/waveform)
-========
+# waveform
 
-Go package capable of generating waveform images from audio streams.  MIT Licensed.
+[![Build Status](https://travis-ci.org/mdlayher/waveform.svg?branch=master)](https://travis-ci.org/mdlayher/waveform)
+[![GoDoc](http://godoc.org/github.com/mdlayher/waveform?status.svg)](http://godoc.org/github.com/mdlayher/waveform)
 
-This library supports any audio streams which the [azul3d/engine/audio](http://azul3d.org/engine/audio)
-package is able to decode.  At the time of writing, this includes:
-  - WAV
-  - FLAC
+Go package capable of generating waveform images from audio streams. MIT
+licensed.
 
-An example binary called `waveform` is provided which show's the library's usage.
-Please see [cmd/waveform/README.md](https://github.com/mdlayher/waveform/blob/master/cmd/waveform/README.md)
+This library supports any audio streams which the
+[azul3d/engine/audio](http://azul3d.org/engine/audio) package is able to decode.
+At the time of writing, this includes:
+
+- WAV
+- FLAC
+
+An example binary called `waveform` is provided which shows the library's usage.
+Please see
+[cmd/waveform/README.md](https://github.com/mdlayher/waveform/blob/master/cmd/waveform/README.md)
 for details.
 
-Examples
-========
+## Examples
 
-Here are several example images generated using `waveform`.  Enjoy!
+Here are several example images generated using `waveform`. Enjoy!
 
 Generate a waveform image, and scale it both vertically and horizontally.
 
-```
+```sh
 $ cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -x 5 -y 2 > ~/waveform.png
 ```
 
@@ -27,7 +32,7 @@ $ cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -x 5 -y 2 > ~/waveform.png
 
 Apply a foreground and background color, to make things more interesting.
 
-```
+```sh
 cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF3300 -bg=#0099CC -x 5 -y 2 > ~/waveform_color.png
 ```
 
@@ -35,7 +40,7 @@ cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF3300 -bg=#0099CC -x 5 
 
 Apply an alternate foreground color, draw using a stripe pattern.
 
-```
+```sh
 cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF3300 -bg=#0099CC -alt=#FF9933 -fn stripe -x 5 -y 2 > ~/waveform_stripe.png
 ```
 
@@ -43,7 +48,7 @@ cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF3300 -bg=#0099CC -alt=
 
 Apply an alternate foreground color, draw using a random fuzz pattern.
 
-```
+```sh
 cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF3300 -bg=#0099CC -alt=#FF9933 -fn fuzz -x 5 -y 2 > ~/waveform_fuzz.png
 ```
 
@@ -51,7 +56,7 @@ cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF3300 -bg=#0099CC -alt=
 
 Apply a new set of colors, draw using a gradient pattern.
 
-```
+```sh
 cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF0000 -bg=#00FF00 -alt=#0000FF -fn gradient -x 5 -y 2 > ~/waveform_gradient.png
 ```
 
@@ -59,7 +64,7 @@ cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#FF0000 -bg=#00FF00 -alt=
 
 Apply a checkerboard color set, draw using a checkerboard pattern.
 
-```
+```sh
 cat ~/Music/02\ -\ Peace\ Of\ Mind.flac | waveform -fg=#000000 -bg=#222222 -alt=#FFFFFF -fn checker -x 5 -y 2 > ~/waveform_checker.png
 ```
 


### PR DESCRIPTION
General changes:

- Consistent line breaks after 80 characters
- Heading levels (`#` for title and `##` for sections)

`LICENSE.md`:

- Replace `(C)` with copyright symbol

`README.md`:

- Badges aren't part of the title anymore
- Small fixes (`MIT Licensed` to `MIT licensed` and `show's` to `shows`)
- Specify language for code snippets